### PR TITLE
Add commit message from oryx; use cherry-pick

### DIFF
--- a/.github/workflows/fetch-and-build-layout.yml
+++ b/.github/workflows/fetch-and-build-layout.yml
@@ -31,13 +31,16 @@ jobs:
       - name: Download layout source
         id: download-layout-source
         run: |
-          response=$(curl --location 'https://oryx.zsa.io/graphql' --header 'Content-Type: application/json' --data '{"query":"query getLayout($hashId: String!, $revisionId: String!, $geometry: String) {layout(hashId: $hashId, geometry: $geometry, revisionId: $revisionId) {  revision { hashId, qmkVersion }}}","variables":{"hashId":"${{ github.event.inputs.layout_id }}","geometry":"${{ github.event.inputs.layout_geometry }}","revisionId":"latest"}}' | jq '.data.layout.revision | [.hashId, .qmkVersion]')
+          response=$(curl --location 'https://oryx.zsa.io/graphql' --header 'Content-Type: application/json' --data '{"query":"query getLayout($hashId: String!, $revisionId: String!, $geometry: String) {layout(hashId: $hashId, geometry: $geometry, revisionId: $revisionId) {  revision { hashId, qmkVersion, title }}}","variables":{"hashId":"${{ github.event.inputs.layout_id }}","geometry":"${{ github.event.inputs.layout_geometry }}","revisionId":"latest"}}' | jq '.data.layout.revision | [.hashId, .qmkVersion, .title]')
           hash_id=$(echo "${response}" | jq -r '.[0]')
           firmware_version=$(printf "%.0f" $(echo "${response}" | jq -r '.[1]'))
+          change_description=$(echo "${response}" | jq -r '.[2]')
           
           curl -L "https://oryx.zsa.io/source/${hash_id}" -o source.zip
           
           echo firmware_version=${firmware_version} >> "$GITHUB_OUTPUT"
+          echo hash_id=${hash_id} >> "$GITHUB_OUTPUT"
+          echo change_description=${change_description} >> "$GITHUB_OUTPUT"
 
       - name: Unzip the source file
         run: |
@@ -49,14 +52,14 @@ jobs:
           git config --local user.name "github-actions"
           git config --local user.email "github-actions@github.com"
           git add .
-          git commit -m "✨ latest layout modification made with Oryx" || echo "No layout change"
+          git commit -m "✨ [oryx]: ${{ steps.download-layout-source.outputs.change_description }}" -m "hash_id: ${{steps.download-layout-source.outputs.hash_id}}" || echo "No layout change"
           git push
 
       - name: Merge Oryx with custom QMK
         run: |
           git fetch origin main
           git checkout -B main origin/main
-          git merge -Xignore-all-space oryx
+          git cherry-pick oryx --empty drop
           git push
 
       - name: Checkout the right firmware branch


### PR DESCRIPTION
Hi!

First of all thanks for this tool, really useful, I actually started something pretty similar in the past in https://github.com/felix-dumit/zsa-firmware, and intended to do github actions but hadn't got around to it yet :D 

This PR adds a couple features that I would like to preserve from my previous version:
- Use the notes input into oryx as the git commit message
- Use git cherry pick instead of merge, to keep the git history flat and without all the merge commits

<img width="723" alt="image" src="https://github.com/user-attachments/assets/62a7d784-3756-4a21-ad5b-08b94860b17e">
