### PR TITLE
Specify keyboard type with choice input

### DIFF
--- a/.github/workflows/fetch-and-build-layout.yml
+++ b/.github/workflows/fetch-and-build-layout.yml
@@ -8,9 +8,19 @@ on:
         required: true
         default: "g7jjw"
       layout_geometry:
-        description: "voyager | moonlander | ergodox_ez | ergodox_ez/stm32/glow | ergodox_ez/stm32/shine | ergodox_ez/m32u4/glow | ergodox_ez/m32u4/shine | planck_ez | planck_ez/glow"
-        required: true
-        default: "voyager"
+        description: "Keyboard type"
+        type: choice
+        options:
+          - voyager
+          - moonlander
+          - ergodox_ez
+          - ergodox_ez/stm32/glow
+          - ergodox_ez/stm32/shine
+          - ergodox_ez/m32u4/glow
+          - ergodox_ez/m32u4/shine
+          - planck_ez
+          - planck_ez/glow
+        default: voyager
 
 permissions:
   contents: write


### PR DESCRIPTION
Limits the allowed inputs for `layout_geometry`. Reference to [`on.workflow_dispatch.inputs` documentation](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs).