### PR TITLE
Commit updates of the qmk_firmware submodule

### DIFF
--- a/.github/workflows/fetch-and-build-layout.yml
+++ b/.github/workflows/fetch-and-build-layout.yml
@@ -74,12 +74,16 @@ jobs:
           git merge -Xignore-all-space oryx
           git push
 
-      - name: Checkout the right firmware branch
+      - name: Update QMK firmware submodule to latest version (${{ steps.download-layout-source.outputs.firmware_version }})
         run: |
           git submodule update --init --remote --depth=1
           cd qmk_firmware
           git checkout -B firmware${{ steps.download-layout-source.outputs.firmware_version }} origin/firmware${{ steps.download-layout-source.outputs.firmware_version }}
           git submodule update --init --recursive
+          cd ..
+          git add qmk_firmware
+          git commit -m "✨(qmk): Update firmware" || true
+          git push
 
       - name: Build qmk docker image
         run: docker build -t qmk .

--- a/.github/workflows/fetch-and-build-layout.yml
+++ b/.github/workflows/fetch-and-build-layout.yml
@@ -82,7 +82,7 @@ jobs:
           git submodule update --init --recursive
           cd ..
           git add qmk_firmware
-          git commit -m "✨(qmk): Update firmware" || true
+          git commit -m "✨(qmk): Update firmware" || echo "No QMK change"
           git push
 
       - name: Build qmk docker image

--- a/.github/workflows/fetch-and-build-layout.yml
+++ b/.github/workflows/fetch-and-build-layout.yml
@@ -76,9 +76,8 @@ jobs:
 
       - name: Checkout the right firmware branch
         run: |
+          git submodule update --init --remote --depth=1
           cd qmk_firmware
-          git submodule update --init --remote
-          git fetch origin firmware${{ steps.download-layout-source.outputs.firmware_version }}
           git checkout -B firmware${{ steps.download-layout-source.outputs.firmware_version }} origin/firmware${{ steps.download-layout-source.outputs.firmware_version }}
           git submodule update --init --recursive
 


### PR DESCRIPTION
I was experimenting with new things I added to the source code and didn't want to wait for GH to finish the workflow (I figured that local compilation will be faster). However, I'm not very bright as it comes to QMK :) 

I thought that the default `qmk_firmware` submodule will work by default, but it didn't. It took me some time to figure out that I should grab the most recent firmware version, which matches the one used by Oryx. I think it would be good to commit the updates to the main repo to avoid any future problems.

This PR changes slightly the firmware checkout step. It will make a shallow copy of the submodule, switch to the `firmwareX` branch (since it's a shallow copy, this will be the latest version) and commit the changes. The changes have been [tested in my forked repo](https://github.com/radmen/zsa-planck-cornish/actions/runs/12602634148).