### PR TITLE
Add extension reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ Each time you run the GitHub Action, the workflow will:
 6. To build the firmware (including both Oryx and code modifications), rerun the GitHub Action. The firmware will be available for download in the action’s artifacts.
 7. Flash your downloaded firmware using [Keymapp](https://www.zsa.io/flash#flash-keymap).
 8. Enjoy!
+
+## Build extension
+
+To make building even easier, you can install the [build extension](https://chromewebstore.google.com/detail/oryx-extension/bocjciklgnhkejkdfilcikhjfbmbcjal) to be able to trigger the Github actions from inside Oryx itself.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ Each time you run the GitHub Action, the workflow will:
 7. Flash your downloaded firmware using [Keymapp](https://www.zsa.io/flash#flash-keymap).
 8. Enjoy!
 
-## Build extension
+## Oryx Chrome extension
 
-To make building even easier, you can install the [build extension](https://chromewebstore.google.com/detail/oryx-extension/bocjciklgnhkejkdfilcikhjfbmbcjal) to be able to trigger the Github actions from inside Oryx itself.
+To make building even easier, @nivekmai created an [Oryx Chrome extension](https://chromewebstore.google.com/detail/oryx-extension/bocjciklgnhkejkdfilcikhjfbmbcjal) to be able to trigger the GitHub Actions from inside Oryx itself.

--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ Each time you run the GitHub Action, the workflow will:
 
 ## Oryx Chrome extension
 
-To make building even easier, @nivekmai created an [Oryx Chrome extension](https://chromewebstore.google.com/detail/oryx-extension/bocjciklgnhkejkdfilcikhjfbmbcjal) to be able to trigger the GitHub Actions from inside Oryx itself.
+To make building even easier, [@nivekmai](https://github.com/nivekmai) created an [Oryx Chrome extension](https://chromewebstore.google.com/detail/oryx-extension/bocjciklgnhkejkdfilcikhjfbmbcjal) to be able to trigger the GitHub Actions from inside Oryx itself.


### PR DESCRIPTION
I created an extension (https://github.com/nivekmai/oryx-build-extension) to be able to trigger the github actions from inside Oryx.

Updating the readme to point to the extension so others can find/use it.