### PR TITLE
✨ Adds support for unlit ergodox_ez with upgraded pcb

### DIFF
--- a/.github/workflows/fetch-and-build-layout.yml
+++ b/.github/workflows/fetch-and-build-layout.yml
@@ -14,11 +14,11 @@ on:
           - voyager
           - moonlander
           - ergodox_ez
-          - ergodox_ez/stm32/main
-          - ergodox_ez/stm32/glow
-          - ergodox_ez/stm32/shine
           - ergodox_ez/m32u4/glow
           - ergodox_ez/m32u4/shine
+          - ergodox_ez/stm32
+          - ergodox_ez/stm32/glow
+          - ergodox_ez/stm32/shine
           - planck_ez
           - planck_ez/glow
         default: voyager

--- a/.github/workflows/fetch-and-build-layout.yml
+++ b/.github/workflows/fetch-and-build-layout.yml
@@ -14,6 +14,7 @@ on:
           - voyager
           - moonlander
           - ergodox_ez
+          - ergodox_ez/stm32/main
           - ergodox_ez/stm32/glow
           - ergodox_ez/stm32/shine
           - ergodox_ez/m32u4/glow


### PR DESCRIPTION
For users that have upgraded an "original" (no glow, no shine) ErgoDox EZ's chipset from m32u4 to stm32, there is now a suitable option that will not enable either `RGB_MATRIX_ENABLE` or `RGBLIGHT_ENABLE`.