### PR TITLE
Tweak QMK update steps for firmware v25

### DIFF
--- a/.github/workflows/fetch-and-build-layout.yml
+++ b/.github/workflows/fetch-and-build-layout.yml
@@ -77,9 +77,10 @@ jobs:
 
       - name: Update QMK firmware submodule to latest version (${{ steps.download-layout-source.outputs.firmware_version }})
         run: |
-          git submodule update --init --remote --depth=1
+          git submodule update --init --remote --depth=1 --no-single-branch
           cd qmk_firmware
           git checkout -B firmware${{ steps.download-layout-source.outputs.firmware_version }} origin/firmware${{ steps.download-layout-source.outputs.firmware_version }}
+          sed -ie 's!git@github.com:!https://github.com/!' .gitmodules
           git submodule update --init --recursive
           cd ..
           git add qmk_firmware

--- a/.github/workflows/fetch-and-build-layout.yml
+++ b/.github/workflows/fetch-and-build-layout.yml
@@ -82,7 +82,6 @@ jobs:
           git submodule update --init --remote --depth=1 --no-single-branch
           cd qmk_firmware
           git checkout -B firmware${{ steps.download-layout-source.outputs.firmware_version }} origin/firmware${{ steps.download-layout-source.outputs.firmware_version }}
-          sed -ie 's!git@github.com:!https://github.com/!' .gitmodules
           git submodule update --init --recursive
           cd ..
           git add qmk_firmware


### PR DESCRIPTION
The ZSA team kindly made the https://github.com/zsa/qmk_modules repo public, which _mostly_ addressed the issue I reported in #40 . I hit a couple additional hiccups though, which I worked around with tweaks to the GitHub Action workflow. Submitting them here in case they're useful more generally.

-----

Make 2 changes to the "Update QMK firmware" step:

- Use `--no-single-branch` when updating the top-level submodule, otherwise `--depth=1` will only fetch the latest commit. That can cause checkouts to fail if the Oryx layout moves to a newer firmware version.

- ~Replace any SSH URLs in qmk_firmware submodules with HTTPS. That's probably a simpler change than wrangling SSH agent configuration inside the job. A tweak _somewhere_ is necessary because Firmware v25 includes a submodule ([modules/zsa](https://github.com/zsa/qmk_firmware/blob/82245288b595ef8e86c6eccbed679192aadf12ac/.gitmodules#L30)) that uses an SSH URL. In a default GitHub Actions setup, that'll fail even for a public repo.~ Removed this bit since the one submodule SSH URL was replaced with HTTPS upstream