### PR TITLE
Explicitly fetch the required firmware branch

### DIFF
--- a/.github/workflows/fetch-and-build-layout.yml
+++ b/.github/workflows/fetch-and-build-layout.yml
@@ -79,7 +79,8 @@ jobs:
         run: |
           git submodule update --init --remote --depth=1
           cd qmk_firmware
-          git checkout -B firmware${{ steps.download-layout-source.outputs.firmware_version }} origin/firmware${{ steps.download-layout-source.outputs.firmware_version }}
+          git fetch origin firmware${{ steps.download-layout-source.outputs.firmware_version }}:firmware${{ steps.download-layout-source.outputs.firmware_version }}
+          git checkout firmware${{ steps.download-layout-source.outputs.firmware_version }}
           git submodule update --init --recursive
           cd ..
           git add qmk_firmware


### PR DESCRIPTION
```
git submodule update --init --remote --depth=1
```

only fetches the default branch (currently `firmware24`). When the firmware version bumps (e.g., to `firmware25`), this is no longer enough to check out the right branch.

This change explicitly fetches the target `firmware${version}` branch into the submodule before checking it out, ensuring the correct version is always available regardless of the default.