### PR TITLE
fix: update actions to use versions with newer node runtime

### DIFF
--- a/.github/workflows/fetch-and-build-layout.yml
+++ b/.github/workflows/fetch-and-build-layout.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: oryx
 
@@ -120,7 +120,7 @@ jobs:
           echo normalized_layout_geometry=${normalized_layout_geometry} >> "$GITHUB_OUTPUT"
 
       - name: Upload layout
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.build-layout.outputs.normalized_layout_geometry }}_${{ github.event.inputs.layout_id }}
           path: ${{ steps.build-layout.outputs.built_layout_file }}


### PR DESCRIPTION
actions/checkout updated to v5 (node v24)
actions/upload-artifact updated to v7 (node v24)